### PR TITLE
Fixed quit bug

### DIFF
--- a/px.py
+++ b/px.py
@@ -621,7 +621,7 @@ def quit():
 		try:
 			p = psutil.Process(pid)
 			if p.exe() == sys.executable:
-				p.send_signal(signal.CTRL_C_EVENT)
+				p.kill()
 		except:
 			pass
 


### PR DESCRIPTION
The quit function was not terminating px.exe processes on my machine.  I tried send_signal(SIGTERM) instead of send_signal(CTRL_C_EVENT) but that didn't work either.  In the end I replaced send_signal(CTRL_C_EVENT) with kill().  Kill may be harsh but it was the only method I found that worked.
