### PR TITLE
Changes helpful with Docker for Windows

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -7,6 +7,11 @@ TBD
 - Changed Pyinstaller to build a single executable file
 - Fixed bug where chunked transfer headers were being returned incorrectly
 - Removed sleep from non-CONNECT methods that was slowing down Px considerably
+- Added "allow" feature to allow (deny) client ip addresses (helpful with Docker for Windows)
+- Added "--gateway" parameter
+- Fixed issue where a HTTP 304 Not Modified response would hang
+- Enabled --debug also for --quit code path
+- Fixed issue where --quit would not be able to stop px instances with different uppercase/lowercase process names
 
 v0.2.1 - 2017-03-30
 - Implemented issue 7 - "listen" setting to configure IP address to bind service to

--- a/README.txt
+++ b/README.txt
@@ -35,10 +35,31 @@ intranet without requiring additional configuration for each client or at the NT
 There are a few other settings to tweak in the INI file but most are self-explanatory. A few
 of the settings can be specified on the command line for convenience.
 
-	px --proxy=proxyserver.com:80 --noproxy=0.0.0.0/0 --debug
-
 The binary distribution of Px runs in the background once started and can be quit by 
 running "px --quit". When run directly using Python, use CTRL-C to quit.
+
+Examples
+
+	Use proxyserver.com:80 and allow requests from localhost only
+	px --proxy=proxyserver.com:80
+
+	Don't use any forward proxy at all, just log what's going on
+	px --proxy= --noproxy=0.0.0.0/0 --debug
+
+	Allow requests from localhost and from your own ip address. This is very useful for Docker
+	for Windows, because in a bridged docker network all requests from containers will originate
+	from your hosts ip.
+	px.exe --proxy=proxyserver.com:80 --gateway --allow=127.0.0.1,<your ip>
+
+	Allow requests from everywhere. Be careful, every client will use your NTLM authentication.
+	px.exe --proxy=proxyserver.com:80 --gateway
+
+Remarks
+In Docker for Windows you need to set your proxy to http://<your ip>:3128 (or whatever port your
+px is listening to) and be aware of https://github.com/docker/for-win/issues/1380. 
+
+Workaround:
+docker build --build-arg http_proxy=http://<your ip>:3128 --build-arg https_proxy=http://<your ip>:3128 -t containername ../dir/with/Dockerfile
 
 Dependencies
 

--- a/px.ini
+++ b/px.ini
@@ -16,6 +16,13 @@ port = 3128
 ;   Overrides listen definition above and binds to all interfaces
 gateway = 0
 
+; Allow connection from following subnets, comma separated
+;   127.0.0.1 - specific ip
+;   192.168.0.* - wildcards
+;   192.168.0.1-192.168.0.255 - ranges
+;   192.168.0.1/24 - CIDR
+allow = *.*.*.*
+
 ; Direct connect to following subnets, comma separated
 ;   Skip the NTLM proxy and connect directly like a regular proxy
 ;   192.168.0.* - wildcards

--- a/px.ini
+++ b/px.ini
@@ -16,7 +16,7 @@ port = 3128
 ;   Overrides listen definition above and binds to all interfaces
 gateway = 0
 
-; Allow connection from following subnets, comma separated
+; Allow connection from following subnets, comma separated - default: *.*.*.*
 ;   127.0.0.1 - specific ip
 ;   192.168.0.* - wildcards
 ;   192.168.0.1-192.168.0.255 - ranges

--- a/px.py
+++ b/px.py
@@ -690,7 +690,7 @@ def quit():
 
         try:
             p = psutil.Process(pid)
-            if p.exe() == sys.executable:
+            if p.exe().lower() == sys.executable.lower():
                 p.send_signal(signal.CTRL_C_EVENT)
         except:
             pass

--- a/px.py
+++ b/px.py
@@ -675,10 +675,6 @@ def parsecli():
         elif "--allow=" in sys.argv[i]:
             parseallow(sys.argv[i].split("=")[1])
 
-    if "--debug" in sys.argv:
-        LOGGER = Log("debug-%s.log" % multiprocessing.current_process().name, "w")
-        DEBUG = True
-
     if "--gateway" in sys.argv:
         LISTEN = ''
 
@@ -717,6 +713,10 @@ def handle_exceptions(type, value, tb):
 if __name__ == "__main__":
     multiprocessing.freeze_support()
     sys.excepthook = handle_exceptions
+
+    if "--debug" in sys.argv:
+        LOGGER = Log("debug-%s.log" % multiprocessing.current_process().name, "w")
+        DEBUG = True
 
     if "--quit" in sys.argv:
         quit()

--- a/px.py
+++ b/px.py
@@ -499,7 +499,7 @@ class PoolMixIn(socketserver.ThreadingMixIn):
         if client_address[0] in ALLOW:
             return True
 
-        print("Client not allowed: %s" % client_address[0])
+        dprint("Client not allowed: %s" % client_address[0])
         return False
 
 class ThreadedTCPServer(PoolMixIn, socketserver.TCPServer):

--- a/px.py
+++ b/px.py
@@ -679,6 +679,9 @@ def parsecli():
         LOGGER = Log("debug-%s.log" % multiprocessing.current_process().name, "w")
         DEBUG = True
 
+    if "--gateway" in sys.argv:
+        LISTEN = ''
+
     if NTLM_PROXY == None:
         print("No proxy defined")
         sys.exit()

--- a/px.py
+++ b/px.py
@@ -610,6 +610,7 @@ def parsecli():
 
     if os.path.exists(INI):
         config = configparser.ConfigParser()
+        config.set(config.default_section, "allow", "*.*.*.*")
         config.read(INI)
 
         if "proxy" in config.sections():

--- a/px.py
+++ b/px.py
@@ -233,7 +233,7 @@ class Proxy(httpserver.SimpleHTTPRequestHandler):
                 dprint("Client closed connection")
                 return 444, None, None
             dprint("Bad response %s" % line)
-        if b"connection established" in line.lower() or resp == 204:
+        if b"connection established" in line.lower() or resp == 204 or resp == 304:
             nobody = True
         dprint("Response code: %d " % resp + str(nobody))
 


### PR DESCRIPTION
Those changes are useful with Docker for Windows (see #https://github.com/docker/for-win/issues/1064, #https://github.com/docker/for-win/issues/1057, #https://github.com/docker/for-win/issues/369).

Reason: With Docker for Windows a proxy is not only used from localhost, but also from inside a container. In a bridged network those connections originate from your local docker host ip address and not localhost, therefore px needs to listen to incoming ip traffic also (--gateway). But opening up a forward proxy with your user authentication to the outside world is not really feasible in a corporate environment. 

With those changes and `px.exe --proxy=<your proxy> --gateway --allow=127.0.0.1,<your ip>` you can now restrict px to listen to network connections from your default bridged docker network only (=from within containers). In Docker for Windows you need to set your proxy to `http://<your ip>:3128` and be aware of #https://github.com/docker/for-win/issues/1380 (Workaround: `docker build --build-arg http_proxy=http://<your ip>:3128 --build-arg https_proxy=http://<your ip>:3128 -t containername ../dir/with/Dockerfile`)
