### PR TITLE
Fixed default values for do_socket()

### DIFF
--- a/px.py
+++ b/px.py
@@ -317,7 +317,7 @@ class Proxy(httpserver.SimpleHTTPRequestHandler):
 
         return False
 
-    def do_socket(self, xheaders=[], destination=None):
+    def do_socket(self, xheaders={}, destination=None):
         dprint("Entering")
 
         # Connect to proxy or destination


### PR DESCRIPTION
xheaders is currently by default initialised as a list, but it should be a dict.