### PR TITLE
Handle pac files that return a list of proxies by taking the first one

### DIFF
--- a/px.py
+++ b/px.py
@@ -1048,6 +1048,9 @@ def find_proxy_for_url(url):
     # and later code uses commas
     proxy_str = proxy_str.replace(';',',')
 
+    # remove any fallback direct values as these won't work with parse_proxy later
+    proxy_str = proxy_str.replace(',DIRECT','')
+
     dprint("Proxy found: " + proxy_str)
     return proxy_str
 

--- a/px.py
+++ b/px.py
@@ -1044,6 +1044,9 @@ def find_proxy_for_url(url):
             dprint("PAC URL is local: " + pac)
         proxy_str = winhttp_find_proxy_for_url(url, pac_url=pac)
 
+    # return the first one if we get a list back from the pac
+    proxy_str = proxy_str.split(';')[0]
+
     dprint("Proxy found: " + proxy_str)
     return proxy_str
 

--- a/px.py
+++ b/px.py
@@ -1051,6 +1051,11 @@ def find_proxy_for_url(url):
     # remove any fallback direct values as these won't work with parse_proxy later
     proxy_str = proxy_str.replace(',DIRECT','')
 
+    # handle edge case if the result is a list that starts with DIRECT just assume 
+    # everything should be direct as the string DIRECT is tested explicitly in get_destination
+    if proxy_str.startswith("DIRECT,"):
+        proxy_str = "DIRECT"
+
     dprint("Proxy found: " + proxy_str)
     return proxy_str
 

--- a/px.py
+++ b/px.py
@@ -1044,8 +1044,9 @@ def find_proxy_for_url(url):
             dprint("PAC URL is local: " + pac)
         proxy_str = winhttp_find_proxy_for_url(url, pac_url=pac)
 
-    # return the first one if we get a list back from the pac
-    proxy_str = proxy_str.split(';')[0]
+    # change it to comma seperated as pac returns semicolon seperated
+    # and later code uses commas
+    proxy_str = proxy_str.replace(';',',')
 
     dprint("Proxy found: " + proxy_str)
     return proxy_str


### PR DESCRIPTION
It's valid for pac files to return a list to allow for failures, this patch simply always takes the first one