### PR TITLE
Default to direct connection is no proxy information is found

### DIFF
--- a/px.py
+++ b/px.py
@@ -1345,6 +1345,8 @@ def find_proxy_for_url(url):
     if proxy_str.startswith("DIRECT,"):
         proxy_str = "DIRECT"
 
+    # If the proxy_str it still empty at this point, then there is no proxy
+    # configured. Try to do a direct connection. 
     if proxy_str == "":
         proxy_str = "DIRECT"
 

--- a/px.py
+++ b/px.py
@@ -1345,6 +1345,9 @@ def find_proxy_for_url(url):
     if proxy_str.startswith("DIRECT,"):
         proxy_str = "DIRECT"
 
+    if proxy_str == "":
+        proxy_str = "DIRECT"
+
     dprint("Proxy found: " + proxy_str)
     return proxy_str
 


### PR DESCRIPTION
If there is no proxy configured in the proxy settings, and no proxy is passed to px manually, then just default to a direct connect. 