### PR TITLE
Add Automated Build System

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ debug-*
 .vscode
 testrun
 *.egg-info
+
+build
+px.spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
     packages:
       - curl
       - software-properties-common
-      - gnupg1
+      - gnupg
       - unzip
       - git
       - apt-transport-https
@@ -18,7 +18,7 @@ addons:
 install:
   - curl -fsSL https://dl.winehq.org/wine-builds/winehq.key | apt-key add -
   - dpkg --add-architecture i386
-  - apt-add-repository "deb https://dl.winehq.org/wine-builds/ubuntu/ bionic main"
+  - apt-add-repository "deb https://dl.winehq.org/wine-builds/ubuntu/ trusty main"
   - apt-get update && apt-get install -y --install-recommends winehq-staging
 script:
   - "./build"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,10 @@ addons:
       - apt-transport-https
       - ca-certificates
 install:
-  - curl -fsSL https://dl.winehq.org/wine-builds/winehq.key | apt-key add -
-  - dpkg --add-architecture i386
-  - apt-add-repository "deb https://dl.winehq.org/wine-builds/ubuntu/ trusty main"
-  - apt-get update && apt-get install -y --install-recommends winehq-staging
+  - curl -fsSL https://dl.winehq.org/wine-builds/winehq.key | sudo apt-key add -
+  - sudo dpkg --add-architecture i386
+  - sudo apt-add-repository "deb https://dl.winehq.org/wine-builds/ubuntu/ trusty main"
+  - sudo apt-get update && sudo apt-get install -y --install-recommends winehq-staging
 script:
   - "./build"
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+language: generic
+sudo: false
+dist: trusty
+branches:
+  only:
+    - master
+    - "/^[0-9].*?-[0-9]{8}$/"
+addons:
+  apt:
+    packages:
+      - curl
+      - software-properties-common
+      - gnupg1
+      - unzip
+      - git
+      - apt-transport-https
+      - ca-certificates
+install:
+  - curl -fsSL https://dl.winehq.org/wine-builds/winehq.key | apt-key add -
+  - dpkg --add-architecture i386
+  - apt-add-repository "deb https://dl.winehq.org/wine-builds/ubuntu/ bionic main"
+  - apt-get update && apt-get install -y --install-recommends winehq-staging
+script:
+  - "./build"
+deploy:
+  provider: releases
+  file: dist/px.exe
+  skip_cleanup: true
+  api_key: "$GITHUB_TOKEN"
+  verbose: true
+  on:
+    tags: true
+env:
+  secure: kuUEhPj/INxg2xGm0AHdmuhBST5ObYZve6Lg3TsiJk9LnVb0iyZV2gBrQ7m86Q5/DMDqPp3e8XB5GBm0V9Iu+PzQgNp6Y770vQ2866bv7PK+GicGiKR/LPFwXoMFeQtVOBuOpopyplZV8PeLEkMQtlQAQjyPqoxAR7MY7Mpo5tyrwnHv0PIzze0FFpdzZ7kQf40pYipvX2WuzssIiwijzSMHwzcGHAYf2GLvH1N1K6PzNIbNLH5jT1O7Xcf4y/nQI4274NdGjz4O2635AHNf/rKOwajCJnv/f08ZKZTmIVbb7C0ApeUojBm0Zed/1nU94j70UIKZ95iZvRoQ/sCQEAH7ybwsLNryt3xyJVreRUVyFRBfoMTMDlussyo6j5KiC5UiAfMq+wca/f0sWMIr2nWogWcF/gCl4289xqN4Olb2VjDOaeqG1pTBkVnitJg1x0RElrX4rExvLd2kYPLo/SefL1Kah8fizFmT+b+5ZXwbQ19bwlj+5BiGPyx5UfLcqY7rY3vHXpR62JJzyHvR6YzeDEfIcoaHc6c6Sl0u7V3x5Gjci7ScBDZJRLjXLRpmmgiz+gKscfN3rAreQy6Yq/cyLt6XcfkmHkiOMkawEnv+AC9kIXyJ224NlpxSShqJPaB/mqkrPkW88wbGZ9SKCk/Rp0zBNpaynZ0kMab8LPo=

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   - sudo apt-add-repository "deb https://dl.winehq.org/wine-builds/ubuntu/ trusty main"
   - sudo apt-get update && sudo apt-get install -y --install-recommends winehq-staging
 script:
-  - "./build"
+  - "./build.sh"
 deploy:
   provider: releases
   file: dist/px.exe

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+temp=$(mktemp -d)
+wd="$(pwd)"
+cd $temp
+curl -fsSL https://www.nuget.org/api/v2/package/python/3.7.3 -o python-nuget.zip
+unzip python-nuget.zip -d python-nuget
+mv python-nuget/tools ./python
+cd python
+curl -fsSL https://bootstrap.pypa.io/get-pip.py -O
+wine python.exe get-pip.py
+wine ./Scripts/pip.exe install keyring netaddr ntlm-auth psutil pywin32 winkerberos futures
+wine ./Scripts/pip.exe install pyinstaller
+cd "$wd"
+wine $temp/python/Scripts/pyinstaller.exe --clean --noupx -w -F -i px.ico px.py --hidden-import win32timezone --exclude-module win32ctypes
+rm -rf $temp


### PR DESCRIPTION
This is a sample of how to employ Travis CI to automate the release process for this project. It will build when a commit is pushed/merged into master, when a new tag is created (`vmajor.minor[.patch]` for releases and `YYYY-MM-DD` for pre-releases) and then the `vHEAD` tag is updated. The only thing that would need to be changed is you would need to add your own GitHub API token (mine is in there, but it won't do anything in your repository since it is encrypted and keyed by the source repo). You can generate the encrypted value with the Travis CLI (docs [here](here)).

I should note that this uses Wine to build px on Linux, instead of using Windows, resulting in a way faster build time. 