### PR TITLE
Break when first auth mechanism is found.

### DIFF
--- a/px.py
+++ b/px.py
@@ -615,10 +615,13 @@ class Proxy(httpserver.SimpleHTTPRequestHandler):
 
                     if "NTLM" in proxy_auth.upper():
                         proxy_type = "NTLM"
+                        break
                     elif "KERBEROS" in proxy_auth.upper():
                         proxy_type = "KERBEROS"
+                        break
                     elif "NEGOTIATE" in proxy_auth.upper():
                         proxy_type = "NEGOTIATE"
+                        break
 
                 if proxy_type is not None:
                     # Writing State.proxy_type only once but use local variable as return value to avoid


### PR DESCRIPTION
In case when more than one proxy authentication mechanisms are available, use the first one (instead the last one).
For my case, NTLM was prefered over Kerberos. I would prefer to use the newer mechanism which is Kerberos.