### PR TITLE
Delete incoming connection headers,

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,17 @@ pip install keyring netaddr ntlm-auth psutil pywin32 winkerberos futures
 python px.py --help
 ```
 
+## Building
+
+To build an executable, run built.bat.  You will need pyinstall (pip install pyinstall) 
+and the microsoft VC++ toolset (pyinstall will prompt you with a link if not present :) ).
+
+If it complains about missing libraries, then you may modify build.bat to give it the path to the MS dlls like:
+
+`pyinstaller --clean --paths "C:\Program Files (x86)\Windows Kits\10\Redist\ucrt\DLLs\x64" --noupx -w -F -i px.ico px.py --hidden-import win32timezone --exclude-module win32ctypes`
+
+substituting the correct path for your system.  (looks like this can also come from the environment).
+
 ## Configuration
 
 Px requires only one piece of information in order to function - the server

--- a/px.py
+++ b/px.py
@@ -775,7 +775,8 @@ class Proxy(httpserver.SimpleHTTPRequestHandler):
 
         if resp.code >= 400:
             dprint("Error %d" % resp.code)
-            self.send_error(resp.code)
+            self.fwd_resp(resp)
+            #self.send_error(resp.code) - we need to send the body of the error too!
         else:
             self.fwd_resp(resp)
 
@@ -830,7 +831,8 @@ class Proxy(httpserver.SimpleHTTPRequestHandler):
         resp = self.do_transaction()
         if resp.code >= 400:
             dprint("Error %d" % resp.code)
-            self.send_error(resp.code)
+            self.fwd_resp(resp)
+            # self.send_error(resp.code) - need to send the whole response back?
         else:
             # Proxy connection may be already closed due to header (Proxy-)Connection: close
             # received from proxy -> forward this to the client

--- a/px.py
+++ b/px.py
@@ -929,6 +929,8 @@ class Proxy(httpserver.SimpleHTTPRequestHandler):
         # Close both proxy and client connection if still open.
         if self.proxy_socket is not None:
             dprint("Cleanup proxy connection")
+            # shutdown the socket before closing - stop it from hanging around
+            self.proxy_socket.shutdown(socket.SHUT_WR)
             self.proxy_socket.close()
             self.proxy_socket = None
         self.close_connection = True


### PR DESCRIPTION
Delete incoming connection headers,
change rlist.clear() to del rlist[;] for python 2.7 comparability
hide log of authorization header.

fixes https://github.com/genotrance/px/issues/71 for me for NEGOCIATE and NTLM

please examine carefully, as I'm no python expert and no HTTP/Proxy expert.

Thankyou for a nice implementation - this is the only thing I found for this purpose :).

