### PR TITLE
Read empty request body when no content-length specified

### DIFF
--- a/px.py
+++ b/px.py
@@ -582,8 +582,11 @@ class Proxy(httpserver.SimpleHTTPRequestHandler):
                 dprint("Getting body for POST/PUT/PATCH")
                 if cl:
                     self.body = self.rfile.read(cl)
+                # elif chk:
+                #     self.body = self.rfile.read()
                 else:
-                    self.body = self.rfile.read()
+                    self.body = ""
+
 
             dprint("Sending body for POST/PUT/PATCH: %d = %d" % (
                 cl or -1, len(self.body)))


### PR DESCRIPTION
Hi,
I found that when I have POST without body (or empty) px hangs with timeout exception while reading incoming socket. As described here https://stackoverflow.com/questions/14758729/http-post-content-length-header-required#comment56261828_14759645 body has to have content-length or chunged encoding specified, if i understand it correctly.
I have commented chunked part, because from my tests it still times out, maybe it means that we have to read chunked data differently. I am not sure if not reading whole incoming socket does not break other things.
What do you think?
Thx
Ivos

```
curl -v -k -X POST http://server:1234/path --header "Authorization: Basic xxx" --header "User-Agent: go-resty/2.0.0 (https://github.com/go-resty/resty)" -x localhost:3128
curl -v -k -X POST http://server:1234/path --header "Authorization: Basic xxx" --header "User-Agent: go-resty/2.0.0 (https://github.com/go-resty/resty)" -x localhost:3128 --data ""
curl -v -k -X POST http://server:1234/path --header "Authorization: Basic xxx" --header "User-Agent: go-resty/2.0.0 (https://github.com/go-resty/resty)" -x localhost:3128 --data "xxx"
curl -v -k -X POST http://server:1234/path --header "Authorization: Basic xxx" --header "User-Agent: go-resty/2.0.0 (https://github.com/go-resty/resty)" -x localhost:3129 -H "Transfer-Encoding: chunked" --data "xxx"
```
error log
```
Process-1: MainThread: 1574750490: verify_request: Client address: 127.0.0.1
Process-1: Thread_0: 1574750490: do_POST: Entering
Process-1: Thread_0: 1574750490: do_GET: Entering
Process-1: Thread_0: 1574750490: do_GET: Path = http://server:1234/path
Process-1: Thread_0: 1574750490: do_transaction: Entering
Process-1: Thread_0: 1574750490: get_destination: server:1234
Process-1: Thread_0: 1574750490: get_destination: http://server:1234/path => ('10.96.24.5', 1234) + /path
Process-1: Thread_0: 1574750490: get_destination: Direct connection from noproxy configuration
Process-1: Thread_0: 1574750490: do_transaction: Skipping auth proxying
Process-1: Thread_0: 1574750490: do_socket: Entering
Process-1: Thread_0: 1574750490: do_socket_connect: New connection: ('10.96.24.5', 1234)
Process-1: Thread_0: 1574750490: do_socket: POST /path HTTP/1.1
Process-1: Thread_0: 1574750490: do_socket: Sending Host: server:1234
Process-1: Thread_0: 1574750490: do_socket: Sending Accept: */*
Process-1: Thread_0: 1574750490: do_socket: Sending Proxy-Connection: Keep-Alive
Process-1: Thread_0: 1574750490: do_socket: Sending Authorization: sanitized len(30)
Process-1: Thread_0: 1574750490: do_socket: Sending User-Agent: go-resty/2.0.0 (https://github.com/go-resty/resty)
Process-1: Thread_0: 1574750490: do_socket: Getting body for POST/PUT/PATCH
MainProcess: Thread_3: 1574750492: do_CONNECT: Connection closed by proxy
MainProcess: Thread_3: 1574750492: do_CONNECT: Cleanup proxy connection
MainProcess: Thread_3: 1574750492: do_CONNECT: 4547 bytes read, 4547 bytes written
MainProcess: Thread_3: 1574750492: do_CONNECT: Done
...
Process-2: Thread_2: 1574750507: handle_one_request: Closed connection to avoid infinite loop
Process-1: Thread_0: 1574750520: log_message: Request timed out: timeout('timed out')
MainProcess: Thread_4: 1574750524: do_CONNECT: Connection closed by client
MainProcess: Thread_4: 1574750524: do_CONNECT: Cleanup proxy connection
MainProcess: Thread_4: 1574750524: do_CONNECT: 1417 bytes read, 1417 bytes written
MainProcess: Thread_4: 1574750524: do_CONNECT: Done
```
configuration
```
[proxy]
server = vsproxy.corporate:8080
pac = 
port = 3129
listen = 127.0.0.1
allow = *.*.*.*
gateway = 0
hostonly = 0
noproxy = 10.*.*.*
#noproxy = *.*.*.*
useragent = 
username = ds\user
auth = 

[settings]
workers = 4
threads = 16
idle = 30
socktimeout = 30.0
proxyreload = 60000
foreground = 1
log = 0
```