### PR TITLE
Adding support for PROXY Servers not adhering to Case-Insensitive Header values

### DIFF
--- a/px.py
+++ b/px.py
@@ -543,7 +543,11 @@ class Proxy(httpserver.SimpleHTTPRequestHandler):
                 h = "%s: %s\r\n" % (header, self.headers[header])
 
             self.proxy_socket.sendall(h.encode("utf-8"))
-            dprint("Sending %s" % h.strip())
+            if hlower != "authorization":
+                dprint("Sending %s" % h.strip())
+            else:
+                dprint("Sending %s: sanitized len(%d)" % (
+                    header, len(self.headers[header])))
 
             if hlower == "content-length":
                 cl = int(self.headers[header])
@@ -566,8 +570,11 @@ class Proxy(httpserver.SimpleHTTPRequestHandler):
         for header in xheaders:
             h = ("%s: %s\r\n" % (header, xheaders[header])).encode("utf-8")
             self.proxy_socket.sendall(h)
-            dprint("Sending extra %s" % h.strip())
-
+            if header.lower() != "proxy-authorization":
+                dprint("Sending extra %s" % h.strip())
+            else:
+                dprint("Sending extra %s: sanitized len(%d)" % (
+                    header, len(xheaders[header])))
         self.proxy_socket.sendall(b"\r\n")
 
         if self.command in ["POST", "PUT", "PATCH"]:
@@ -631,8 +638,10 @@ class Proxy(httpserver.SimpleHTTPRequestHandler):
             name = nv[0].strip()
             value = nv[1].strip()
             resp.headers.append((name, value))
-            dprint("Received %s: %s" % (name, value))
-
+            if name.lower() != "proxy-authenticate":
+                dprint("Received %s: %s" % (name, value))
+            else:
+                dprint("Received %s: sanitized (%d)" % (name, len(value)))
 
             if name.lower() == "content-length":
                 resp.length = int(value)

--- a/px.py
+++ b/px.py
@@ -543,11 +543,7 @@ class Proxy(httpserver.SimpleHTTPRequestHandler):
                 h = "%s: %s\r\n" % (header, self.headers[header])
 
             self.proxy_socket.sendall(h.encode("utf-8"))
-            if hlower != "authorization":
-                dprint("Sending %s" % h.strip())
-            else:
-                dprint("Sending %s: sanitized len(%d)" % (
-                    header, len(self.headers[header])))
+            dprint("Sending %s" % h.strip())
 
             if hlower == "content-length":
                 cl = int(self.headers[header])
@@ -570,11 +566,8 @@ class Proxy(httpserver.SimpleHTTPRequestHandler):
         for header in xheaders:
             h = ("%s: %s\r\n" % (header, xheaders[header])).encode("utf-8")
             self.proxy_socket.sendall(h)
-            if header.lower() != "proxy-authorization":
-                dprint("Sending extra %s" % h.strip())
-            else:
-                dprint("Sending extra %s: sanitized len(%d)" % (
-                    header, len(xheaders[header])))
+            dprint("Sending extra %s" % h.strip())
+
         self.proxy_socket.sendall(b"\r\n")
 
         if self.command in ["POST", "PUT", "PATCH"]:
@@ -638,10 +631,8 @@ class Proxy(httpserver.SimpleHTTPRequestHandler):
             name = nv[0].strip()
             value = nv[1].strip()
             resp.headers.append((name, value))
-            if name.lower() != "proxy-authenticate":
-                dprint("Received %s: %s" % (name, value))
-            else:
-                dprint("Received %s: sanitized (%d)" % (name, len(value)))
+            dprint("Received %s: %s" % (name, value))
+
 
             if name.lower() == "content-length":
                 resp.length = int(value)

--- a/px.py
+++ b/px.py
@@ -672,8 +672,7 @@ class Proxy(httpserver.SimpleHTTPRequestHandler):
                         proxy_auth += header[1] + " "
 
                 for auth in proxy_auth.split():
-                    auth_verification = auth.upper()
-                    if auth_verification in ["NTLM", "KERBEROS", "NEGOTIATE", "BASIC"]:
+                    if auth.upper() in ["NTLM", "KERBEROS", "NEGOTIATE", "BASIC"]:
                         proxy_type = auth
                         break
 

--- a/px.py
+++ b/px.py
@@ -672,8 +672,8 @@ class Proxy(httpserver.SimpleHTTPRequestHandler):
                         proxy_auth += header[1] + " "
 
                 for auth in proxy_auth.split():
-                    auth = auth.upper()
-                    if auth in ["NTLM", "KERBEROS", "NEGOTIATE", "BASIC"]:
+                    auth_verification = auth.upper()
+                    if auth_verification in ["NTLM", "KERBEROS", "NEGOTIATE", "BASIC"]:
                         proxy_type = auth
                         break
 

--- a/px.py
+++ b/px.py
@@ -740,7 +740,7 @@ class Proxy(httpserver.SimpleHTTPRequestHandler):
                     ntlm_challenge = ""
                     for header in resp.headers:
                         if (header[0].lower() == "proxy-authenticate" and
-                                proxy_type in header[1].upper()):
+                                proxy_type.upper() in header[1].upper()):
                             h = header[1].split()
                             if len(h) == 2:
                                 ntlm_challenge = h[1]


### PR DESCRIPTION
 Some proxy servers (e.g. ZScaler) do not adhere to the [RFC2617](https://tools.ietf.org/html/rfc2617#section-1.2) by not accepting the Proxy-Authorisation header value when capitalised. These tokens should be case insensitive (NEGOTIATE vs Negotiate ) but in case of Zscaler Authentication fails as a result.

This change will echo the auth-scheme back to the server exactly as it was received to ensure compatibility. 