### PR TITLE
Fix encodestring/decodestring for Python3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language : shell
 
 env:
-  - CONDA_PYTHON=2.7
   - CONDA_PYTHON=3.5
   - CONDA_PYTHON=3.6
   - CONDA_PYTHON=3.7
+  - CONDA_PYTHON=3.9
 
 os :
 - windows

--- a/px.py
+++ b/px.py
@@ -345,13 +345,13 @@ def b64decode(val):
     try:
         return base64.decodebytes(val.encode("utf-8"))
     except AttributeError:
-        return base64.decodestring(val)
+        return base64.decodebytes(val)
 
 def b64encode(val):
     try:
         return base64.encodebytes(val.encode("utf-8"))
     except AttributeError:
-        return base64.encodestring(val)
+        return base64.encodebytes(val)
 
 class AuthMessageGenerator:
     def __init__(self, proxy_type, proxy_server_address):


### PR DESCRIPTION
Deprecated methods in the base64 module had to be replaced by their new equivalent.