### PR TITLE
Fix genotrance/px#164

### DIFF
--- a/px/pac.py
+++ b/px/pac.py
@@ -86,4 +86,4 @@ class Pac:
 
     def myIpAddress(self):
         "Get my IP address"
-        return dnsResolve(socket.gethostname())
+        return self.dnsResolve(socket.gethostname())


### PR DESCRIPTION
This fixes the issue #164. A class method does not known about other class methods, so the keyword self has to be used.
In my tests, this fixed the issue and PAC parsing works :)