### PR TITLE
feat: process noproxy rules even with MODE_CONFIG_PAC

### DIFF
--- a/px/main.py
+++ b/px/main.py
@@ -838,7 +838,7 @@ def parse_config():
     if len(servers) != 0:
         State.wproxy = wproxy.Wproxy(wproxy.MODE_CONFIG, servers, State.noproxy, debug_print = dprint)
     elif len(State.pac) != 0:
-        State.wproxy = wproxy.Wproxy(wproxy.MODE_CONFIG_PAC, [State.pac], debug_print = dprint)
+        State.wproxy = wproxy.Wproxy(wproxy.MODE_CONFIG_PAC, [State.pac], State.noproxy, debug_print = dprint)
     else:
         State.wproxy = wproxy.Wproxy(debug_print = dprint)
         State.proxy_last_reload = time.time()


### PR DESCRIPTION
When using PX in MODE_CONFIG_PAC, noproxy rules are ignored.
This commit indicates required changes in order to have the expected behavior.