### PR TITLE
Add GSSAPI to authentication info check

### DIFF
--- a/px/handler.py
+++ b/px/handler.py
@@ -101,8 +101,11 @@ def set_curl_auth(curl, auth):
             if sys.platform == "win32":
                 dprint(curl.easyhash + ": Using SSPI to login")
                 key = ":"
+            if sys.platform == "linux":
+                dprint(curl.easyhash + ": Using GSSAPI to login")
+                key = ":"
             else:
-                dprint("SSPI not available and no username configured - no auth")
+                dprint("SSPI/GSSPI not available and no username configured - no auth")
                 return
         curl.set_auth(user = key, password = pwd, auth = auth)
     else:


### PR DESCRIPTION
Fixes #208 

On Linux SSPI is not available, but GSSAPI is. Kerberos still works on linux, the easiest way to gain a TGT is using `kinit username@DOMAIN` if dns is configured probably.

libcurl needs to be compiled with Feature GSS-API, but on most distributions, it is by default. 

