### PR TITLE
fix: upx needs to be forced to be packed on macos.

### DIFF
--- a/tools.py
+++ b/tools.py
@@ -249,7 +249,8 @@ def nuitka():
             os.system("upx --best px.exe python3*.dll libcrypto*.dll")
         else:
             os.rename("px.bin", "px")
-            os.system("upx --best px")
+            force_macos_flag = "" if sys.platform != "darwin" else "--force-macos "
+            os.system(f"upx --best {force_macos_flag}px")
 
     # Create archive
     os.chdir("..")


### PR DESCRIPTION
UPX 4.2.4 ends with 

```
upx: px: CantPackException: macOS is currently not supported (try --force-macos)

Packed 0 files.
```

Added the recommended flag in nuitka code path.