### PR TITLE
Check reused parent pid when looking for console to attach to

### DIFF
--- a/px/windows.py
+++ b/px/windows.py
@@ -95,7 +95,7 @@ def attach_console(state):
     ppid_with_console = -1
     for par in process.parents():
         if os.path.basename(par.name()).lower() in [
-                "cmd", "cmd.exe", "powershell", "powershell.exe"]:
+                "cmd", "cmd.exe", "powershell", "powershell.exe", "pwsh", "pwsh.exe"]:
             # Found it
             ppid_with_console = par.pid
             break


### PR DESCRIPTION
I was unlucky when tried to run from task sheduler with pythonw.exe.

A parent pid was reused and this created an endless loop when walking the parents.
Something like
??? (686)  ->  wininit(1023) -> services.exe (782) -> svchost (686) -> pythonw (2034)
pid 686 died before services.exe was started, but its pid was reused.

Changed the code to use psutil.Process.parents(), which checks for this.

Also added pwsh to the list of shells when looking for a console.